### PR TITLE
Add async skincare recommender pipeline

### DIFF
--- a/skincare_recommender/__init__.py
+++ b/skincare_recommender/__init__.py
@@ -1,0 +1,5 @@
+"""Skin-care recommender package."""
+
+from . import agents
+
+__all__ = ["agents"]

--- a/skincare_recommender/agents/explanation_llm.py
+++ b/skincare_recommender/agents/explanation_llm.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from typing import List, Dict, Any
+
+from openai import AsyncOpenAI
+
+
+async def generate_explanation(api_key: str, ranking: List[Dict[str, Any]]) -> str:
+    """Generate explanations for the ranked products using OpenAI asynchronously."""
+    client = AsyncOpenAI(api_key=api_key)
+    prompt = "Provide a concise explanation for recommending the following products:\n"
+    for item in ranking:
+        prompt += f"- {item.get('name')} (score {item.get('score'):.2f})\n"
+    resp = await client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    explanation = resp.choices[0].message.content
+    return explanation
+
+
+def save_explanation(text: str, path: str) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"explanation": text}, f, indent=2)

--- a/skincare_recommender/agents/orchestrator.py
+++ b/skincare_recommender/agents/orchestrator.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import TypedDict, Dict, Any, List
+
+from langgraph.graph import StateGraph, END, START
+from rich.console import Console
+
+from . import (
+    questionnaire,
+    profile_builder,
+    product_filter,
+    similarity_scorer,
+    rank_aggregator,
+    explanation_llm,
+)
+
+console = Console()
+
+
+class RecommenderState(TypedDict, total=False):
+    answers: Dict[str, Any]
+    profile: Dict[str, Any]
+    filtered: List[Dict[str, Any]]
+    scores: List[float]
+    ranking: List[Dict[str, Any]]
+    explanation: str
+
+
+async def node_questionnaire(state: RecommenderState, question_path: str, output_dir: Path) -> RecommenderState:
+    df = questionnaire.load_questionnaire(question_path)
+    answers = questionnaire.collect_answers(df)
+    (output_dir / "answers.json").write_text(json.dumps(answers, indent=2))
+    return {"answers": answers}
+
+
+def node_profile(state: RecommenderState, output_dir: Path) -> RecommenderState:
+    profile = profile_builder.build_profile(state["answers"])
+    profile_builder.save_profile(profile, output_dir / "profile.json")
+    return {"profile": profile}
+
+
+def node_filter(state: RecommenderState, catalog_path: str, output_dir: Path) -> RecommenderState:
+    products = product_filter.load_catalog(catalog_path)
+    filtered = product_filter.filter_products(products, state["profile"])
+    product_filter.save_products(filtered, output_dir / "filtered.json")
+    return {"filtered": filtered}
+
+
+def node_similarity(state: RecommenderState, output_dir: Path) -> RecommenderState:
+    scores = similarity_scorer.score_similarity(state["filtered"], state["profile"])
+    similarity_scorer.save_scores(scores, output_dir / "scores.json")
+    return {"scores": scores}
+
+
+def node_rank(state: RecommenderState, output_dir: Path) -> RecommenderState:
+    ranking = rank_aggregator.mmr_ranking(state["filtered"], state["scores"])
+    rank_aggregator.save_ranking(ranking, output_dir / "ranking.json")
+    return {"ranking": ranking}
+
+
+async def node_explanation(state: RecommenderState, api_key: str, output_dir: Path) -> RecommenderState:
+    explanation = await explanation_llm.generate_explanation(api_key, state["ranking"])
+    explanation_llm.save_explanation(explanation, output_dir / "explanation.json")
+    return {"explanation": explanation}
+
+
+async def run_pipeline(questionnaire_path: str, catalog_path: str, api_key: str, output_dir: str = "outputs") -> None:
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    graph = StateGraph(RecommenderState)
+
+    async def q_node(state: RecommenderState) -> RecommenderState:
+        return await node_questionnaire(state, questionnaire_path, out_dir)
+
+    def profile_node(state: RecommenderState) -> RecommenderState:
+        return node_profile(state, out_dir)
+
+    def filter_node(state: RecommenderState) -> RecommenderState:
+        return node_filter(state, catalog_path, out_dir)
+
+    def similarity_node(state: RecommenderState) -> RecommenderState:
+        return node_similarity(state, out_dir)
+
+    def rank_node(state: RecommenderState) -> RecommenderState:
+        return node_rank(state, out_dir)
+
+    async def explain_node(state: RecommenderState) -> RecommenderState:
+        return await node_explanation(state, api_key, out_dir)
+
+    graph.add_node("ask_questions", q_node)
+    graph.add_node("build_profile", profile_node)
+    graph.add_node("filter_products", filter_node)
+    graph.add_node("score_similarity", similarity_node)
+    graph.add_node("rank_products", rank_node)
+    graph.add_node("explain", explain_node)
+
+    graph.add_edge(START, "ask_questions")
+    graph.add_edge("ask_questions", "build_profile")
+    graph.add_edge("build_profile", "filter_products")
+    graph.add_edge("filter_products", "score_similarity")
+    graph.add_edge("score_similarity", "rank_products")
+    graph.add_edge("rank_products", "explain")
+    graph.add_edge("explain", END)
+
+    compiled = graph.compile()
+
+    result: RecommenderState = await compiled.ainvoke({})
+    # final explanation
+    console.print("\n[bold underline]Recommendations[/bold underline]")
+    for item in result.get("ranking", []):
+        console.print(f"- {item.get('name')} (score {item.get('score'):.2f})")
+    console.print("\n[bold]Explanation:[/bold]", result.get("explanation", ""))
+
+
+async def main(questionnaire_path: str, catalog_path: str, api_key: str, output_dir: str = "outputs") -> None:
+    await run_pipeline(questionnaire_path, catalog_path, api_key, output_dir)
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+
+    if len(sys.argv) < 3:
+        print("Usage: python -m skincare_recommender.agents.orchestrator QUESTIONNAIRE.xlsx CATALOG.json")
+        sys.exit(1)
+
+    q_path = sys.argv[1]
+    cat_path = sys.argv[2]
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        print("OPENAI_API_KEY environment variable required")
+        sys.exit(1)
+    asyncio.run(main(q_path, cat_path, api_key))

--- a/skincare_recommender/agents/product_filter.py
+++ b/skincare_recommender/agents/product_filter.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Any
+
+import pandas as pd
+
+
+def load_catalog(path: str | Path) -> List[Dict[str, Any]]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        data = data.get("products", [])
+    return data
+
+
+def filter_products(products: List[Dict[str, Any]], profile: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Filter products based on profile labels."""
+    filtered = []
+    for product in products:
+        tags = {t.lower() for t in product.get("tags", [])}
+        match = True
+        for trait in profile.keys():
+            if trait.lower() in tags:
+                continue
+            match = False
+            break
+        if match:
+            filtered.append(product)
+    return filtered
+
+
+def save_products(products: List[Dict[str, Any]], path: str) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(products, f, indent=2)

--- a/skincare_recommender/agents/profile_builder.py
+++ b/skincare_recommender/agents/profile_builder.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from typing import Dict, Any
+
+import pandas as pd
+
+
+# Example weights from Algorithm 1 (Eq. 3-7)
+WEIGHTS = {
+    "dry": 1.0,
+    "oily": 0.8,
+    "sensitive": 1.2,
+    "acne": 1.5,
+}
+
+
+def build_profile(answers: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a user skin profile applying weights defined in the algorithm."""
+    profile: Dict[str, Any] = {}
+    for key, val in answers.items():
+        weight = WEIGHTS.get(key.lower(), 1.0)
+        profile[key] = {"answer": val, "weight": weight}
+    return profile
+
+
+def save_profile(profile: Dict[str, Any], path: str) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(profile, f, indent=2)

--- a/skincare_recommender/agents/questionnaire.py
+++ b/skincare_recommender/agents/questionnaire.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pandas as pd
+from pathlib import Path
+from typing import Dict, Any
+
+
+def load_questionnaire(path: str | Path) -> pd.DataFrame:
+    """Load diagnostic questionnaire from an Excel file."""
+    df = pd.read_excel(path)
+    return df
+
+
+def collect_answers(df: pd.DataFrame) -> Dict[str, Any]:
+    """Simple CLI questionnaire returning answers as a dictionary."""
+    answers: Dict[str, Any] = {}
+    for _, row in df.iterrows():
+        question = row.get("question") or str(row.get("Question"))
+        if not isinstance(question, str):
+            continue
+        options = row.get("options") or row.get("Options")
+        prompt = f"{question}"
+        if isinstance(options, str):
+            prompt += f" ({options})"
+        prompt += ": "
+        ans = input(prompt)
+        answers[question] = ans
+    return answers

--- a/skincare_recommender/agents/rank_aggregator.py
+++ b/skincare_recommender/agents/rank_aggregator.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from typing import List, Dict, Any
+
+
+def mmr_ranking(products: List[Dict[str, Any]], scores: List[float], lambda_param: float = 0.5, top_k: int = 5) -> List[Dict[str, Any]]:
+    """Perform Maximal Marginal Relevance ranking."""
+    ranked = []
+    selected_indices = []
+    scores = list(scores)
+
+    while len(ranked) < min(top_k, len(products)):
+        best_idx = None
+        best_val = -float("inf")
+        for i, s in enumerate(scores):
+            if i in selected_indices:
+                continue
+            diversity = 0.0
+            for j in selected_indices:
+                diversity = max(diversity, 1 - abs(scores[i] - scores[j]))
+            value = lambda_param * s - (1 - lambda_param) * diversity
+            if value > best_val:
+                best_val = value
+                best_idx = i
+        if best_idx is None:
+            break
+        selected_indices.append(best_idx)
+        ranked.append(products[best_idx] | {"score": scores[best_idx]})
+    return ranked
+
+
+def save_ranking(ranking: List[Dict[str, Any]], path: str) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(ranking, f, indent=2)

--- a/skincare_recommender/agents/similarity_scorer.py
+++ b/skincare_recommender/agents/similarity_scorer.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Any
+
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+
+VECTOR_FIELDS = ["ingredients", "description"]
+
+
+def build_product_matrix(products: List[Dict[str, Any]]) -> tuple[np.ndarray, List[str]]:
+    texts = []
+    for product in products:
+        text = " ".join(str(product.get(field, "")) for field in VECTOR_FIELDS)
+        texts.append(text)
+    vectorizer = TfidfVectorizer(stop_words="english")
+    matrix = vectorizer.fit_transform(texts)
+    return matrix, vectorizer
+
+
+def score_similarity(products: List[Dict[str, Any]], profile: Dict[str, Any]) -> List[float]:
+    matrix, vectorizer = build_product_matrix(products)
+    profile_text = " ".join(key for key in profile.keys())
+    profile_vec = vectorizer.transform([profile_text])
+    sims = cosine_similarity(profile_vec, matrix).flatten()
+    return sims.tolist()
+
+
+def save_scores(scores: List[float], path: str) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(scores, f, indent=2)

--- a/skincare_recommender/cli.py
+++ b/skincare_recommender/cli.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+import asyncio
+from pathlib import Path
+from rich.console import Console
+
+from .agents import orchestrator
+
+console = Console()
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Skin-care product recommender")
+    parser.add_argument("questionnaire", help="Path to diagnostic questionnaire Excel file")
+    parser.add_argument("catalog", help="Path to product catalog JSON file")
+    parser.add_argument("--output", default="outputs", help="Directory to save outputs")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        console.print("[red]OPENAI_API_KEY environment variable required[/red]")
+        raise SystemExit(1)
+
+    asyncio.run(orchestrator.main(args.questionnaire, args.catalog, api_key, args.output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new `skincare_recommender` package with CLI
- implement async LangGraph orchestration of questionnaire, profile building, filtering, similarity scoring, MMR ranking and explanation
- use OpenAI `AsyncOpenAI` for explanations
- store intermediate artifacts to disk

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m skincare_recommender.cli --help`

------
https://chatgpt.com/codex/tasks/task_e_68466c7543b8832e950cc358b4de3f60